### PR TITLE
Added restore confirmation prompt to prevent overwriting (Issue #5)

### DIFF
--- a/autobackup.sh
+++ b/autobackup.sh
@@ -1,3 +1,14 @@
+if [ "$1" == "--restore" ]; then
+    echo "Are you sure you want to overwrite existing files? (y/n)"
+    read answer
+    if [ "$answer" != "y" ]; then
+        echo "Restore canceled by user."
+        exit 0
+    fi
+    # Continue with restore process
+    cp -r ~/Desktop/AutoBackupVault/Backups/* ~/Desktop/AutoBackupVault/SourceFiles/
+    echo "$(date): Restore completed" >> ~/Desktop/AutoBackupVault/report.txt
+fi
 # Log rotation
 LOG_FILE=~/Desktop/AutoBackupVault/report.txt
 MAX_SIZE=1048576  # 1 MB in bytes


### PR DESCRIPTION
This PR resolves Issue #16 raised by Nandini by adding a confirmation prompt 
before overwriting existing files during restore. 
Restore actions are logged in report.txt.